### PR TITLE
#5: Remove console.log() from markdown-deluxe.js

### DIFF
--- a/lib/markdown-deluxe.js
+++ b/lib/markdown-deluxe.js
@@ -13,7 +13,6 @@ if (!this.grammarsAdded) {
       }
       var grammar = atom.grammars.grammarsByScopeName['source.gfm'];
       var patterns = grammar.rawPatterns;
-      console.log(patterns);
 
       patterns.push({
         begin: "^([\\s]{4,})",


### PR DESCRIPTION
See issue #5 
