### PR TITLE
Center .editor--private instead of atom-text-editor

### DIFF
--- a/lib/markdown-deluxe.js
+++ b/lib/markdown-deluxe.js
@@ -49,8 +49,12 @@ var Run = {
         maxWidth = atom.config.get('markdown-deluxe.width');
 
 var styles = `[data-markdown-deluxe="true"] {
-  max-width: ${maxWidth};
   font: ${fontSize} ${fontFamily};
+}
+
+[data-markdown-deluxe="true"]::shadow .editor--private {
+  max-width: ${maxWidth};
+  margin: 0 auto;
 }
 
 [data-markdown-deluxe="true"]::shadow .markup.raw,


### PR DESCRIPTION
This makes sure the minimap stays at the outer edge, instead of moving to the center with the content.

That's the way _I_ prefer it, at least. I like to keep the minimap to get an overview of longer documents, but it looks too crammed up against the text. This gives the main content more room to breathe.

Surely this change is up for discussion.
